### PR TITLE
lasfix

### DIFF
--- a/ChatTutor/core/tutor/sqlquerytutor.py
+++ b/ChatTutor/core/tutor/sqlquerytutor.py
@@ -151,9 +151,12 @@ class SQLQueryTutor(Tutor):
             ]
         )
         required_level_of_information.resolve()
+        print("\nREQUIRED LEVEL OF INFO\n\n\n", required_level_of_information)
+
         return required_level_of_information.text
 
     def get_required_type_of_information(self, prompt, explain=False):
+        return "CONTENT"
         # if self.gemini == False:
         #     return self.get_required_level_of_information_openai(prompt, explain)
         respond_with = ""
@@ -412,6 +415,7 @@ class SQLQueryTutor(Tutor):
 
         if self.prequery:
             query = required_level_of_information
+            # query = "NONE"
             query_text = "NONE"
             sql_query_data = None
             if query != "NONE" and from_doc == None:

--- a/ChatTutor/core/vectordatabase.py
+++ b/ChatTutor/core/vectordatabase.py
@@ -119,7 +119,7 @@ class VectorDatabase:
         self, collection_name, extra=["titles", "summary", "authors", "citations"]
     ):
         """Load Chroma collection"""
-        openai_ef = embedding_functions.Text2VecEmbeddingFunction()
+        openai_ef = None
 
         if self.ef == "openai":
             openai_ef = embedding_functions.OpenAIEmbeddingFunction(
@@ -139,7 +139,7 @@ class VectorDatabase:
 
     def load_datasource_chroma(self, collection_name):
         """Load Chroma collection"""
-        openai_ef = embedding_functions.Text2VecEmbeddingFunction()
+        openai_ef = None
 
         if self.ef == "openai":
             openai_ef = embedding_functions.OpenAIEmbeddingFunction(

--- a/ChatTutor/frontend/src/app/chat-window/chat-window.component.html
+++ b/ChatTutor/frontend/src/app/chat-window/chat-window.component.html
@@ -6,16 +6,30 @@
         src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
       </script>
     <div class="chat-messages">
-        <div class="chat-header-title">
-            <a href="/"><h3>{{chat_title}}</h3></a>
-            <div *ngIf="restrictToDocument != undefined">
-                <span>{{ "The chatbot will now ONLY answer questions about " + getDocTitle(restrictToDocument)}}</span>
+        <div class="chat-header-title" style=" margin-top: 0;">
+            <a href="{{chat_title_link}}"><h3>{{chat_title}}</h3></a>
+            <div *ngIf="restrictToDocument != undefined" class="col-cent">
+                <div class="col-cent">
+                    <span>The chatbot will now <u>ONLY</u> answer questions about </span>
+                    
+                    <div *ngIf="getDocLink(restrictToDocument)=='#'">
+                        <span>{{getDocTitle(restrictToDocument)}}</span> 
+                    </div>
+                    <div *ngIf="getDocLink(restrictToDocument)!='#'">
+                        <a href="{{getDocLink(restrictToDocument)}}">{{getDocTitle(restrictToDocument)}}</a> 
+                    </div>
+                </div>
+                
 
 <!--                <p>{{restrictToDocument | json}}</p>-->
 
-                To exit, click <button (click)="clearRestriction()">
-                    here
-                </button>
+                <div class="row-cent">
+                    <span>To exit, click </span>
+                    <button mat-button color="primary" (click)="clearRestriction()">
+                        here
+                    </button>
+
+                </div>
 
             </div>
         </div>

--- a/ChatTutor/frontend/src/app/cqnchat-tutor-wrapper/cqnchat-tutor-wrapper.component.html
+++ b/ChatTutor/frontend/src/app/cqnchat-tutor-wrapper/cqnchat-tutor-wrapper.component.html
@@ -2,7 +2,7 @@
 <app-nsf-paper-nav (updateContextRestriction)="restrict($event)">
 
 </app-nsf-paper-nav>
-<app-chat-window [chat_title]="'ChatCQN'" [openingMessage]="'
+<app-chat-window [chat_title]="'ChatCQN'" [chat_title_link]="'https://cqn-erc.org/'" [openingMessage]="'
 Hello, welcome to ChatCQN!
 You can use this tool to learn about anything related to quantum networks, and all of the exciting work happening at the NSF Center for Quantum Networks. Here are some example prompts:
 - Please explain quantum networking to me at the level of a high schooler!

--- a/ChatTutor/frontend/src/app/docheader/docheader.component.html
+++ b/ChatTutor/frontend/src/app/docheader/docheader.component.html
@@ -1,6 +1,6 @@
 <div class="docheader">
     <div *ngIf="document != undefined">
-        <mat-card class="example-card" [class.reduced]="!full">
+        <mat-card class="example-card">
             <mat-card-header (click)="toggleDocument()">
                 <!--                <div *ngIf="document.metadata.entry_id">-->
                 <!--                    <mat-card-subtitle>Paper</mat-card-subtitle>-->
@@ -10,9 +10,9 @@
                 <!--                </div>-->
                 <!--                <mat-card-title>{{document.metadata.doc}}</mat-card-title>-->
                 <div style="display: flex; flex-direction: column;">
-                    <div style="width: 30px"><mat-icon>chevron_right</mat-icon></div>
+                    <!-- <div style="width: 30px"><mat-icon>chevron_right</mat-icon></div> -->
                     <a [href]="document.metadata.links ? document.metadata.links : '#'">
-                        <span *ngIf="document.metadata.title">
+                        <span *ngIf="document.metadata.title" style="word-break: break-word; word-wrap: break-word;">
                             {{ document.metadata.title }}
                         </span>
                     </a>
@@ -29,9 +29,9 @@
                             Focus on for more information about authors / content.
                         </span>
                     </div>
-                    <div *ngIf="document.metadata.authors">
+                    <div *ngIf="document.metadata.authors" class="row" style="word-break: break-word; flex-wrap: wrap !important;">
                         <div *ngFor="let author of document.metadata.authors[document.metadata.doc]['author']">
-                            <span>{{ author['name'] }}&nbsp;,</span>
+                            <span>{{author['name']}},&nbsp;</span>
                         </div>
                     </div>
 
@@ -46,8 +46,8 @@
                 <mat-divider></mat-divider>
             </mat-card-content>
             <mat-card-actions>
-                <button mat-button (click)="focusOnDocument()" *ngIf="!showHeader">Focus (Click to learn more about this
-                    paper)
+                <button mat-button (click)="focusOnDocument()" *ngIf="!showHeader">Click <u>here</u> to learn more about this
+                    paper
                 </button>
                 <button mat-button (click)="closeInfoBox()" *ngIf="showHeader">CLOSE</button>
             </mat-card-actions>

--- a/ChatTutor/frontend/src/app/docheader/docheader.component.ts
+++ b/ChatTutor/frontend/src/app/docheader/docheader.component.ts
@@ -7,12 +7,15 @@ import {Message} from 'app/models/message.model';
   templateUrl: './docheader.component.html',
   styleUrls: ['./docheader.component.css']
 })
-export class DocheaderComponent {
+export class DocheaderComponent implements OnInit {
   @Input() document: any = {};
   @Input() showHeader: boolean = true;
   @Output() onClose: EventEmitter<any> = new EventEmitter();
   @Output() onFocus: EventEmitter<any> = new EventEmitter();
   @Output() onClick: EventEmitter<any> = new EventEmitter();
+
+  ngOnInit(): void { 
+  }
 
   @Input() full: any = true;
   closeInfoBox() {

--- a/ChatTutor/frontend/src/app/input-box/input-box.component.ts
+++ b/ChatTutor/frontend/src/app/input-box/input-box.component.ts
@@ -20,13 +20,18 @@ export class InputBoxComponent implements OnChanges{
     ngOnChanges(changes: SimpleChanges) {
         console.log(changes)
         if (changes['status']) {
-            console.log(changes['status'])
+            console.log("Changes!!: ", changes['status'])
             if (changes['status'].currentValue == WStatus.GeneratingMessage || 
                 changes['status'].currentValue == WStatus.LoadingMessage) {
                     this.canSend = false;
                     this.canStop = true;
                     this.canClear = false;
                 }
+            else {
+                this.canSend = true;
+                this.canStop = false;
+                this.canClear = true;
+            }
         }
     }
 
@@ -54,12 +59,14 @@ export class InputBoxComponent implements OnChanges{
 
     clearChat() {
         this.clearConvo.emit('');
-        // this.canClear = false;
+        this.canClear = false;
+        this.canStop = true
     }
 
     stopChat() {
         this.stopConvo.emit('')
         this.canClear = true;
+        this.canStop = false
     }
 
 }

--- a/ChatTutor/frontend/src/app/nsf-paper-nav/nsf-paper-nav.component.css
+++ b/ChatTutor/frontend/src/app/nsf-paper-nav/nsf-paper-nav.component.css
@@ -104,6 +104,7 @@
     border-radius: 5px;
     background-color: #f6f4ff !important;
     margin: 5px;
+    min-width: 50%;
 }
 
 .column {

--- a/ChatTutor/frontend/src/app/nsf-paper-nav/nsf-paper-nav.component.html
+++ b/ChatTutor/frontend/src/app/nsf-paper-nav/nsf-paper-nav.component.html
@@ -68,9 +68,9 @@
 
                     <div style="text-align: center">
                         <div style="background-color: #8a00fb; color: white !important; padding: 3px; margin: 3px; text-align: center; border-radius: 5px; overflow-x: scroll">
-                            <button style="background: transparent; text-align: center; border: none; color: white"
+                            <button mat-button color="primary"
                                     (click)="doc_restrictContext(doc)">
-                                Focus (Click to learn more about this paper)
+                                Click <b>here</b> to learn more about this paper
                             </button>
                         </div>
                     </div>
@@ -105,8 +105,8 @@
 <div *ngIf="full_screen"
      (click)="toggle_full_screen(); $event.stopPropagation()"
      style="position: fixed; width: 100vw; height: 100vh; background-color: rgba(255, 255, 255, 0.01); z-index: 100 !important;">
-    <div>
-        <button type="button" mat-fab mat-mini-fab color="primary" matTooltip="Close"
+    <div style="margin: 20px;">
+        <button type="button" mat-fab mat-mini-fab color="primary" matTooltip="Close" 
                 (click)="toggle_full_screen()" style="z-index: 999">
             <mat-icon class="icon-display">close</mat-icon>
         </button>
@@ -133,26 +133,39 @@
 
 
         </mat-form-field>
-        <div class="row" style="justify-content: center; padding: 20px !important;">
-            <div *ngIf="author_search_semnul_intrebarii">
-                <div class="author_display">
-                    <div *ngFor="let author of displayed_authors">
+        <div class="row" style="justify-content: flex-start; padding: 20px !important; position: relative;">
+            <div *ngIf="author_search_semnul_intrebarii" style="position: relative;  flex-grow: 2;">
+                <div class="author_display"  style="position: relative; flex-grow: 2;">
+                    <div *ngFor="let author of displayed_authors" style="position: relative;">
                         <div class="author_card column" (click)="get_author_papers(author['author_id'])">
-                            <h3 (click)="get_author_papers(author['author_id'])">{{ author['name'] }}</h3>
+                            <div *ngIf="author['link'] != 'no_link' && author['link'] != 'none'">
+                                <a [href]="author['link']" target="_blank">
+                                    <h3 (click)="get_author_papers(author['author_id'])">{{ author['name'] }}</h3>
+                                </a>
+                            </div>
+                            <div *ngIf="author['link'] == 'no_link' || author['link'] == 'none'">
+                                <h3 (click)="get_author_papers(author['author_id'])">{{ author['name'] }}</h3>
+                            </div>
+
+                            <button mat-button color="primary" (click)="get_author_papers(author['author_id'])">
+                                <span>See papers of {{author['name']}}</span>
+                            </button>
                             <!--                        <a (click)="get_author_papers(author['author_id'])">Scholar ID: {{ author['author_id'] }}</a>-->
                             <div *ngIf="author['link'] != 'no_link' && author['link'] != 'none'">
-                                <a [href]="author['link']" target="_blank">Scholar Link: {{ author['link'] }}</a>
+                                Scholar Link: <a [href]="author['link']" target="_blank">{{ author['link'] }}</a>
                             </div>
+
                         </div>
                     </div>
                 </div>
             </div>
+            <div *bgIf="!show_back_button"></div>
             <div *ngIf="show_back_button"
                  [style]='"max-width: " + (author_search_semnul_intrebarii ? "50% !important;" : "100% !important;")'>
-<!--                <button type="button" mat-fab mat-mini-fab color="primary" matTooltip="Go back to authors"-->
-<!--                        matTooltipPosition="left" (click)="paper_back()">-->
-<!--                    <mat-icon class="icon-display">keyboard_arrow_left</mat-icon>-->
-<!--                </button>-->
+               <button type="button" mat-fab mat-mini-fab color="primary" matTooltip="Go back to authors"
+                       matTooltipPosition="left" (click)="just_back()">
+                   <mat-icon class="icon-display">keyboard_arrow_left</mat-icon>
+               </button>
                 <h3>{{ displayed_papers_author['name'] }}</h3>
 
                 <div *ngIf="loading_author">
@@ -166,12 +179,22 @@
                         <!--                        <span>-->
                         <!--                            Scholar Paper ID: {{ doc['metadata']['info']['paper']["result_id"] }}-->
                         <!--                        </span>-->
-
-                        <a [href]="doc['metadata']['info']['paper']['link']">
+                        <div *ngIf="doc['metadata']['info']['paper']['link'] == undefined || doc['metadata']['info']['paper']['link'] == 'no_link'">
+                            
                             <h3>
                                 {{ doc['metadata']['info']['paper']['title'] }}
                             </h3>
-                        </a>
+                            <span>No accessible link found for this paper.</span>
+                        </div>
+
+
+                        <div *ngIf="doc['metadata']['info']['paper']['link'] != undefined && doc['metadata']['info']['paper']['link'] != 'no_link'">
+                            <a [href]="doc['metadata']['info']['paper']['link']">
+                                <h3>
+                                    {{ doc['metadata']['info']['paper']['title'] }}
+                                </h3>
+                            </a>
+                        </div>
                         <!-- <div>
                             {{doc['metadata']['info'] | json}}
                         </div> -->
@@ -191,9 +214,9 @@
                             {{ doc['metadata']['info']['paper']["snippet"] }}
                         </div>
 
-                        <button style="background: transparent; text-align: center; border: none; color: black"
+                        <button mat-button color="primary"
                                 (click)="doc_restrictContext(doc)">
-                            Focus (Click to learn more about this paper)
+                            Click <u>here</u> to learn more about this paper.
                         </button>
                     </div>
                     <br/>
@@ -208,12 +231,12 @@
 
 
 <div class="example-sidenav-content" style="position: fixed; top: 20px; right: 50px; z-index: 19000;">
-    <button class="btn" type="button" color="primary" matTooltip="Explore CQN papers"
+    <button mat-button color="primary" class="btn" type="button" color="primary" matTooltip="Explore CQN papers"
             (click)="toggle_full_screen_papers()">
         <span>Search papers</span>
     </button>
 
-    <button class="btn" type="button" color="primary" matTooltip="Explore CQNauthors"
+    <button mat-button color="primary" class="btn" type="button" color="primary" matTooltip="Explore CQNauthors"
             (click)="toggle_full_screen_authors()">
         <span>Search authors</span>
     </button>

--- a/ChatTutor/frontend/src/app/nsf-paper-nav/nsf-paper-nav.component.ts
+++ b/ChatTutor/frontend/src/app/nsf-paper-nav/nsf-paper-nav.component.ts
@@ -41,6 +41,7 @@ export class NsfPaperNavComponent implements OnInit {
         let author_data = await this.dataProvider.nsfGetAllAuthors()
         this.all_authors = author_data["data"]
         this.displayed_authors = this.all_authors
+        this.displayed_authors_stack.push(this.displayed_authors)
     }
 
     set_mode(sm: string) {
@@ -107,7 +108,10 @@ export class NsfPaperNavComponent implements OnInit {
                 }
             })
             console.log(this.displayed_papers)
-            this.displayed_papers_author = {name: "Results for: `" + this.author_input + "`"}
+            if (this.author_input.length == 0)
+                this.displayed_papers_author = {name: "All results"}
+            else
+                this.displayed_papers_author = {name: "Your Search: `" + this.author_input + "`"}
             this.show_back_button = true
 
         }
@@ -115,7 +119,7 @@ export class NsfPaperNavComponent implements OnInit {
 
     async search_papers_default() {
         let paper_data = await this.dataProvider.nsfGetAllPapersByName('quantum')
-
+        console.log(paper_data, "paper_fata")
         if (this.default_displayed_papers.length == 0) {
             this.displayed_papers = paper_data["data"].map((x: any) => {
                 return {
@@ -133,7 +137,10 @@ export class NsfPaperNavComponent implements OnInit {
 
 
         console.log(this.displayed_papers)
-        this.displayed_papers_author = {name: "Results for: `" + this.author_input + "`"}
+        if (this.author_input.length == 0)
+            this.displayed_papers_author = {name: "All results"}
+        else
+            this.displayed_papers_author = {name: "Your Search: `" + this.author_input + "`"}
         this.show_back_button = true
     }
 
@@ -168,7 +175,18 @@ export class NsfPaperNavComponent implements OnInit {
         this.show_back_button = false
         this.displayed_papers = []
         this.displayed_authors = this.displayed_authors_stack[this.displayed_authors.length - 1]
-        this.displayed_authors_stack.pop()
+        if (this.displayed_authors_stack.length > 0)
+            this.displayed_authors_stack.pop()
+    }
+
+    just_back() {
+        this.show_back_button = true
+        this.displayed_papers = this.default_displayed_papers
+        this.displayed_authors = this.displayed_authors_stack[this.displayed_authors.length - 1]
+        if (this.displayed_authors_stack.length > 0)
+            this.displayed_authors_stack.pop()
+        this.displayed_papers_author = {name: "All results"}
+        this.displayed_authors = this.all_authors
     }
 
     async send() {

--- a/ChatTutor/frontend/src/styles.css
+++ b/ChatTutor/frontend/src/styles.css
@@ -48,6 +48,14 @@ body { margin: 0; font-family: 'Montserrat', sans-serif; }
     flex-direction: column;
 }
 
+.col-cent {
+    display: flex;
+    flex-direction: column;
+    align-content: center;
+    align-items: center;
+    justify-content: center;
+}
+
 .row {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
- [x] Having serious problems with latency. most important thing is that it responds in reasonable time. Not every response needs to be context gathering. `hopefully it's faster now :))`
- [x] ChatCQN header should not link back to chattutor.org, just eliminate the link
- [x] When you click on Search Papers, at the top you get Results for: ``. Should just say “All results”, and then when you actually submit a search, you should see Results for: ‘your search’
- [x] When you clikc on Search Papers, and you scroll down, there are a bunch of paper names with links that are purple, and when you click on them they route back to chattutor.org
- [x] Instead of saying “Focus (Click more to learn about this paper)“, just say “Click here to learn more about this paper”. This should also be a button object, currently you can’t tell that you can click here. Also, at the top where it says “The chatbot will now ONLY answer questions about On the capacity region of a quantum switch with entanglement purification”, you should hyperlink the paper, and have “To exit click here” pushed to the next line
- [x] When you click on search authors, exit out, then click on search papers, you have a split window with “Results for ‘’” on the right. There should be no paper search feature in the search authors feature (it should just function like it does when you click on an author and it splits the window, but there should be an exit button that takes you back to the initial search authors feature. right now if i click on an author there is no way to go back and see the whole list of authors).
- [x] When you click on search authors, some authors have scholar links under their name, but these should be hyperlinked to their name.
- [x] When i enter a search query and click enter, nothing happens. Enter should do the same thing as pressing the search button `[was fixed already]`
- [x] When I enter a prompt in the chat application, and the chatbot responds, the “X” to clear the chat goes away, and the stop button still shows up. Instead, the X should return (like it is when you refresh the application) Please check if we actually fixed it:)
- [x] When i type in a message like “Hello”, papers are still returned. Instead, papers should only be returned if it is relevant to the users prompt (so sometimes no papers should be returned) !! [we talked abt this, it would take an extra llm call to figure out, we can market it as: ’The bot gives a sample of papers so you can check them out if you don’t know exactly what to ask it on point.’]
- [x] When papers are returned on the right, shouldn’t list authors. Also, should have word wrapping (currently have cases where parts of words are moving to the next line, like “Quant” on one line then “um” on next line). Also, all the returned papers should have the button saying “Click here to learn more about this paper”, so you can get rid of the drop down.
when you refresh, it should save the previous chat, not reset the chat
- [x] have had issues with typing a simple prompt and it breaking and not returning anything `[maybe repetitive prompts, or small ones. they break the API, if you encounter the error again, screen record it here. this i dont think if chattutor’s fault, it is. from the openai api]`